### PR TITLE
event register not working with vue-events 3.0.0

### DIFF
--- a/src/components/MyVuetable.vue
+++ b/src/components/MyVuetable.vue
@@ -152,20 +152,26 @@ export default {
     onCellClicked (data, field, event) {
         console.log('cellClicked: ', field.name)
         this.$refs.vuetable.toggleDetailRow(data.id)
-    }
-  },
-  events: {
-    'filter-set' (filterText) {
+    },
+    onFilterSet (filterText) {
       this.moreParams = {
         'filter': filterText
       }
       Vue.nextTick( () => this.$refs.vuetable.refresh())
     },
-    'filter-reset' () {
+    onFilterReset () {
       this.moreParams = {}
       this.$refs.vuetable.refresh()
       Vue.nextTick( () => this.$refs.vuetable.refresh())
     }
+  },
+  mounted() {
+    this.$events.listen('filter-set', filterText => this.onFilterSet(filterText))
+    this.$events.listen('filter-reset', this.onFilterSet)
+  },
+  beforeDestroy() {
+    this.$events.remove('filter-set')
+    this.$events.remove('filter-reset')
   }
 }
 </script>


### PR DESCRIPTION
Hi Rati,
Thanks for your great vuetable2 module and tutorials. They helped me a lot.
Currently vue-events vue-2.x acutually installs 3.0.0 packege, which removed the support of registering event listeners using the events option.  https://github.com/cklmercer/vue-events#usage 
So it might be a good idea to update to the latest style it supports.

...Fox